### PR TITLE
[wordpress]ヘッダーの構成を見直す

### DIFF
--- a/template/functions.php
+++ b/template/functions.php
@@ -12,3 +12,37 @@ add_action('wp_enqueue_scripts', 'enqueue_scripts');
 
 //管理バーの削除
 add_filter('show_admin_bar', '__return_false');
+
+//ページごとにbodyにクラス追加
+add_filter('body_class', 'custom_body_class');
+function custom_body_class($classes){
+  $classes[] = get_child_class();
+  return $classes;
+}
+
+function get_child_class(){
+	$class = '';
+    if (isFlorenceA()){
+      $class = 'florenceA';
+    } else if (isFlorenceB()){
+		  $class = 'florenceB';
+	}
+  return $class;
+}
+
+//URLによって情報を取得する
+function isTop(){
+	return !isFlorenceA() && !isFlorenceB() && !isGallery();
+}
+
+function isFlorenceA(){
+	return strpos(strtolower($_SERVER["REQUEST_URI"]), 'florencea');
+}
+	
+function isFlorenceB(){
+	return strpos(strtolower($_SERVER["REQUEST_URI"]), 'florenceb');
+}
+
+function isGallery(){
+	return strpos(strtolower($_SERVER["REQUEST_URI"]), 'gallery');
+}

--- a/template/header.php
+++ b/template/header.php
@@ -1,9 +1,20 @@
-<!DOCTYPE html>
 <html lang="ja">
   <head>
     <link
       href="https://fonts.googleapis.com/css2?family=Kiwi+Maru:wght@300&display=swap"
       rel="stylesheet"
+    />
+	  <link
+      href="https://fonts.googleapis.com/css2?family=Dosis:wght@600&display=swap"
+      rel="stylesheet"
+    />
+	  <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/lightgallery/2.7.0/css/lightgallery.min.css"
+    />
+	  <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/lightgallery/2.7.0/css/lg-thumbnail.min.css"
     />
     <link
       href="https://fonts.googleapis.com/icon?family=Material+Icons"
@@ -15,10 +26,10 @@
     <title>Florence</title>
     <?php wp_head(); ?>
   </head>
-<body>
+<body <?php body_class(); ?> >
   <header class="header">
     <div class="header__logo">
-      <a href="#">
+      <a href="<?php echo esc_url(home_url()); ?>">
         <img
           class="header__pc-logo"
           src="<?php echo get_stylesheet_directory_uri(); ?>/img/Florence_logo.svg"
@@ -33,15 +44,27 @@
     </div>
     <nav class="navigation">
       <ul class="navigation__card">
-        <li class="navigation__item">
-          <a class="navigation__link" href="#about">About</a>
-        </li>
-        <li class="navigation__item">
-          <a class="navigation__link" href="#apartment">Apartment</a>
-        </li>
+		    <?php if (!isGallery()) { ?>
+			  <li class="navigation__item">
+				  <a class="navigation__link" href="#about">About</a>
+				</li>
+			  <?php if (isTop()) { ?>
+				<li class="navigation__item">
+				  <a class="navigation__link" href="#apartment">Apartment</a>
+			  </li>
+				<?php } ?>
+			  <?php if (!isTop()) { ?>
+				<li class="navigation__item">
+				  <a class="navigation__link" href="#feature">Feature</a>
+			  </li>
+				<li class="navigation__item">
+				  <a class="navigation__link" href="#gallery">Gallery</a>
+			  </li>
+			  <?php } ?>
         <li class="navigation__item">
           <a class="navigation__link" href="#information">Information</a>
         </li>
+		    <?php } ?>
         <li class="navigation__item">
           <a class="navigation__link" href="#contact">Contact</a>
         </li>
@@ -54,4 +77,3 @@
     </nav>
   </header>
   <div class="menu__background"></div>
-


### PR DESCRIPTION
fix #153 

## 目的
ヘッダーに条件式を書き、表示する内容をページごとに制御できるようにした

## やったこと
- ページごとにbodyタグにクラスを追加した
- URLによって情報を判別できる条件式を書いた
- ヘッダーに表示する内容を判別する式を書いた

## イメージ
![スクリーンショット 2022-12-08 2 34 49](https://user-images.githubusercontent.com/110820784/206251358-914d089d-b3cb-4eac-a72f-913f5996ad0c.png)
